### PR TITLE
Add summary section

### DIFF
--- a/lib/body/summary_section.dart
+++ b/lib/body/summary_section.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class SummarySection extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Summary:',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            color: Colors.black,
+          ),
+        ),
+        SizedBox(height: 8.0),
+        const Text(
+          '''Experienced Senior Software Developer with more than 12 years of expertise in
+developing and implementing scalable solutions. 
+Driven by a passion for innovative software design and architecture, I am
+seeking opportunities to apply my skills in Senior technical roles, contributing
+to the strategic and technical success of forward-thinking projects.''',
+        ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'header/header.dart';
 import 'header/header_column.dart';
+import 'body/summary_section.dart';
 import 'body/experience_section.dart';
 import 'body/education_section.dart';
 import 'body_column/skills_section.dart'; // Importar el componente SkillsSection
@@ -57,6 +58,8 @@ class MyHomePage extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Header(),
+                        SizedBox(height: 24.0),
+                        SummarySection(),
                         SizedBox(height: 24.0),
                         ExperienceSection(),
                         SizedBox(height: 24.0),


### PR DESCRIPTION
## Summary
- add a SummarySection widget
- insert SummarySection below header

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504d1e5c88832c900ef000df42afc4