### PR TITLE
Add profile image to resume header

### DIFF
--- a/lib/header/header.dart
+++ b/lib/header/header.dart
@@ -3,26 +3,40 @@ import 'package:flutter/material.dart';
 class Header extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Text(
-          'Hernán Javier Funes',
-          textAlign: TextAlign.center,
-          style: const TextStyle(
-            fontSize: 39,
-            fontWeight: FontWeight.bold,
-            color: Color(0xFF003366),
+        ClipOval(
+          child: Image.asset(
+            'resources/me_simpson.png',
+            width: 80,
+            height: 80,
+            fit: BoxFit.cover,
           ),
         ),
-        SizedBox(height: 8.0),
-        Text(
-          'Software Engineer | Software Architect | Technical Lead',
-          textAlign: TextAlign.center,
-          style: const TextStyle(
-            fontSize: 24,
-            fontWeight: FontWeight.bold,
-            color: Color(0xFF4A4A4A),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Hernán Javier Funes',
+                style: TextStyle(
+                  fontSize: 39,
+                  fontWeight: FontWeight.bold,
+                  color: Color(0xFF003366),
+                ),
+              ),
+              const SizedBox(height: 8.0),
+              const Text(
+                'Software Engineer | Software Architect | Technical Lead',
+                style: TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                  color: Color(0xFF4A4A4A),
+                ),
+              ),
+            ],
           ),
         ),
       ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,9 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
+  assets:
+    - resources/me_simpson.png
+
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
## Summary
- display `me_simpson.png` to the left of header text
- register `resources/me_simpson.png` as an asset in `pubspec.yaml`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851898d9ff0832ca4cc32152622a04a