### PR TITLE
Fix Tools section layout

### DIFF
--- a/lib/body_column/tools_section.dart
+++ b/lib/body_column/tools_section.dart
@@ -3,9 +3,11 @@ import 'package:flutter/material.dart';
 class ToolsSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
+    return SizedBox(
+      width: 240.0,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
         const Text(
           'TOOLS AND TECHNOLOGIES',
           style: TextStyle(


### PR DESCRIPTION
## Summary
- keep the `Tools and Technologies` section width fixed so text wraps instead of stretching the column

## Testing
- `flutter format lib/body_column/tools_section.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519193c4c0832caf43d50882abcb8e