### PR TITLE
Update tools section and layout

### DIFF
--- a/lib/body_column/tools_section.dart
+++ b/lib/body_column/tools_section.dart
@@ -17,47 +17,96 @@ class ToolsSection extends StatelessWidget {
         SizedBox(height: 24.0),
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('• Java Servlet', style: TextStyle(fontSize: 10)),
-            Text('• AJAX', style: TextStyle(fontSize: 10)),
-            Text('• REST', style: TextStyle(fontSize: 10)),
-            Text('• SOAP', style: TextStyle(fontSize: 10)),
-            Text('• Apache Struts', style: TextStyle(fontSize: 10)),
-            Text('• Spring Framework', style: TextStyle(fontSize: 10)),
-            Text('• HTML', style: TextStyle(fontSize: 10)),
-            Text('• jQuery', style: TextStyle(fontSize: 10)),
-            Text('• Bootstrap', style: TextStyle(fontSize: 10)),
-            Text('• Angular JS', style: TextStyle(fontSize: 10)),
-            Text('• Ionic Framework', style: TextStyle(fontSize: 10)),
-            Text('• Android SDK', style: TextStyle(fontSize: 10)),
-            Text('• Flutter', style: TextStyle(fontSize: 10)),
-            Text('• Hibernate', style: TextStyle(fontSize: 10)),
-            Text('• MySQL', style: TextStyle(fontSize: 10)),
-            Text('• PostgreSQL', style: TextStyle(fontSize: 10)),
-            Text('• Apache Maven', style: TextStyle(fontSize: 10)),
-            Text('• Apache Tomcat Server', style: TextStyle(fontSize: 10)),
-            Text('• Apache Web Server', style: TextStyle(fontSize: 10)),
-            Text('• Linux Server', style: TextStyle(fontSize: 10)),
-            Text('• Windows Server', style: TextStyle(fontSize: 10)),
-            Text('• Bash', style: TextStyle(fontSize: 10)),
-            Text('• Windows PowerShell', style: TextStyle(fontSize: 10)),
-            Text('• SVN', style: TextStyle(fontSize: 10)),
-            Text('• Git', style: TextStyle(fontSize: 10)),
-            Text('• Gitlab CI/CD', style: TextStyle(fontSize: 10)),
-            Text('• GitHub Actions', style: TextStyle(fontSize: 10)),
-            Text('• Jenkins', style: TextStyle(fontSize: 10)),
-            Text('• Selenium', style: TextStyle(fontSize: 10)),
-            Text('• Active Directory', style: TextStyle(fontSize: 10)),
-            Text('• Sistemas embebidos', style: TextStyle(fontSize: 10)),
-            Text('• Arduino', style: TextStyle(fontSize: 10)),
-            Text('• Novell Netware', style: TextStyle(fontSize: 10)),
-            Text('• Mantis', style: TextStyle(fontSize: 10)),
-            Text('• Redmine', style: TextStyle(fontSize: 10)),
-            Text('• Trello', style: TextStyle(fontSize: 10)),
-            Text('• Asana', style: TextStyle(fontSize: 10)),
-            Text('• Octane', style: TextStyle(fontSize: 10)),
-            Text('• Miró', style: TextStyle(fontSize: 10)),
-            Text('• Instagantt', style: TextStyle(fontSize: 10)),
+          children: const [
+            Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(text: '• ', style: TextStyle(fontSize: 10)),
+                  TextSpan(
+                      text: 'Programming languages ',
+                      style: TextStyle(
+                          fontSize: 10, fontWeight: FontWeight.bold)),
+                  TextSpan(
+                      text:
+                          'Java, Kotlin, JavaScript, HTML, Bootstrap, jQuery, Angular Js, Flutter, Android, Go.',
+                      style: TextStyle(fontSize: 10)),
+                ],
+              ),
+            ),
+            Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(text: '• ', style: TextStyle(fontSize: 10)),
+                  TextSpan(
+                      text: 'Development Frameworks and Tools ',
+                      style: TextStyle(
+                          fontSize: 10, fontWeight: FontWeight.bold)),
+                  TextSpan(
+                      text:
+                          'Spring/SpringBoot, Apache Struts, Maven, Gradle, Hibernate, Ionic, Git, SVN.',
+                      style: TextStyle(fontSize: 10)),
+                ],
+              ),
+            ),
+            Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(text: '• ', style: TextStyle(fontSize: 10)),
+                  TextSpan(
+                      text: 'Databases ',
+                      style: TextStyle(
+                          fontSize: 10, fontWeight: FontWeight.bold)),
+                  TextSpan(
+                      text:
+                          'MySQL, PostgreSQL, DynamoDB, SQLite, Redis.',
+                      style: TextStyle(fontSize: 10)),
+                ],
+              ),
+            ),
+            Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(text: '• ', style: TextStyle(fontSize: 10)),
+                  TextSpan(
+                      text: 'DevOps ',
+                      style: TextStyle(
+                          fontSize: 10, fontWeight: FontWeight.bold)),
+                  TextSpan(
+                      text:
+                          'AWS, Docker, GitLab CI/CD, GitHub Actions, Jenkins, Apache Web Server, IIS, Apache Tomcat, Wildfly.',
+                      style: TextStyle(fontSize: 10)),
+                ],
+              ),
+            ),
+            Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(text: '• ', style: TextStyle(fontSize: 10)),
+                  TextSpan(
+                      text: 'Monitoring ',
+                      style: TextStyle(
+                          fontSize: 10, fontWeight: FontWeight.bold)),
+                  TextSpan(
+                      text: 'AWS Cloudwatch, New Relic.',
+                      style: TextStyle(fontSize: 10)),
+                ],
+              ),
+            ),
+            Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(text: '• ', style: TextStyle(fontSize: 10)),
+                  TextSpan(
+                      text: 'Operating Systems ',
+                      style: TextStyle(
+                          fontSize: 10, fontWeight: FontWeight.bold)),
+                  TextSpan(
+                      text:
+                          'Linux / Linux server, Windows / Windows Server, MacOs, Bash, Windows PowerShell, Embedded Systems.',
+                      style: TextStyle(fontSize: 10)),
+                ],
+              ),
+            ),
           ],
         ),
       ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,6 +56,7 @@ class MyHomePage extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Expanded(
+                    flex: 3,
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -71,18 +72,21 @@ class MyHomePage extends StatelessWidget {
                     ),
                   ),
                   SizedBox(width: 24.0),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      HeaderColumn(),
-                      SizedBox(height: 24.0),
-                      SkillsSection(),
-                      SizedBox(height: 24.0),
-                      ToolsSection(),
-                      SizedBox(height: 24.0),
-                      LanguagesSection(),
-                      SizedBox(height: 24.0),
-                    ],
+                  Expanded(
+                    flex: 1,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        HeaderColumn(),
+                        SizedBox(height: 24.0),
+                        SkillsSection(),
+                        SizedBox(height: 24.0),
+                        ToolsSection(),
+                        SizedBox(height: 24.0),
+                        LanguagesSection(),
+                        SizedBox(height: 24.0),
+                      ],
+                    ),
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- overhaul Tools and technologies list
- set column layout ratio to 75/25

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541b0d3e3c832caa043c56d55d173c