### PR TITLE
Fix summary text formatting

### DIFF
--- a/lib/body/summary_section.dart
+++ b/lib/body/summary_section.dart
@@ -16,11 +16,8 @@ class SummarySection extends StatelessWidget {
         ),
         SizedBox(height: 8.0),
         const Text(
-          '''Experienced Senior Software Developer with more than 12 years of expertise in
-developing and implementing scalable solutions. 
-Driven by a passion for innovative software design and architecture, I am
-seeking opportunities to apply my skills in Senior technical roles, contributing
-to the strategic and technical success of forward-thinking projects.''',
+          'Experienced Senior Software Developer with more than 12 years of expertise in developing and implementing scalable solutions. Driven by a passion for innovative software design and architecture, I am seeking opportunities to apply my skills in Senior technical roles, contributing to the strategic and technical success of forward-thinking projects.',
+          style: TextStyle(fontSize: 12),
         ),
       ],
     );


### PR DESCRIPTION
## Summary
- keep summary body text on a single line
- set the summary body font size to 12px

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854564297a0832ca1a6df8f7575e17f