### PR TITLE
Fix unselectable text on web build

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -36,6 +36,12 @@
     // The value below is injected by flutter build, do not touch.
     const serviceWorkerVersion = null;
   </script>
+  <script>
+    // Force the HTML renderer so that text is selectable on web.
+    window.flutterConfiguration = {
+      renderer: "html",
+    };
+  </script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script>
 </head>


### PR DESCRIPTION
## Summary
- force HTML renderer in `web/index.html` so users can select text

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545c7c2424832c82d39bb5d15dc965