### PR TITLE
Add emoji icons to header and enable clickable links

### DIFF
--- a/lib/header/header_column.dart
+++ b/lib/header/header_column.dart
@@ -1,35 +1,52 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class HeaderColumn extends StatelessWidget {
+  const HeaderColumn({super.key});
+
+  Future<void> _launch(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
   @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: const [
-        Text(
-          'Buenos Aires, Argentina',
+      children: [
+        const Text(
+          '🌍 Buenos Aires, Argentina',
           style: TextStyle(
             fontSize: 12,
             color: Color(0xFF6A6A6A),
           ),
         ),
-        SizedBox(height: 8),
-        Text(
-          'github.com/hfunescom',
-          style: TextStyle(
-            fontSize: 12,
-            color: Color(0xFF6A6A6A),
+        const SizedBox(height: 8),
+        InkWell(
+          onTap: () => _launch('https://github.com/hfunescom'),
+          child: const Text(
+            '🐙 github.com/hfunescom',
+            style: TextStyle(
+              fontSize: 12,
+              color: Color(0xFF6A6A6A),
+              decoration: TextDecoration.underline,
+            ),
           ),
         ),
-        SizedBox(height: 8),
-        Text(
-          'http://linkedin.com/in/hernan-javier-funes',
-          style: TextStyle(
-            fontSize: 12,
-            color: Color(0xFF6A6A6A),
+        const SizedBox(height: 8),
+        InkWell(
+          onTap: () => _launch('https://linkedin.com/in/hernan-javier-funes'),
+          child: const Text(
+            '💼 http://linkedin.com/in/hernan-javier-funes',
+            style: TextStyle(
+              fontSize: 12,
+              color: Color(0xFF6A6A6A),
+              decoration: TextDecoration.underline,
+            ),
           ),
         ),
-        SizedBox(height: 16),
+        const SizedBox(height: 16),
       ],
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
   google_fonts: ^6.1.0
+  url_launcher: ^6.1.10
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- use url_launcher for tapping links
- add world, octopus, and briefcase emojis to the header texts

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685464425448832c87660109b552448e