### PR TITLE
Refactor header links

### DIFF
--- a/lib/header/header_column.dart
+++ b/lib/header/header_column.dart
@@ -23,28 +23,52 @@ class HeaderColumn extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 8),
-        InkWell(
-          onTap: () => _launch('https://github.com/hfunescom'),
-          child: const Text(
-            '🐙 github.com/hfunescom',
-            style: TextStyle(
-              fontSize: 12,
-              color: Color(0xFF6A6A6A),
-              decoration: TextDecoration.underline,
+        Row(
+          children: [
+            const Text(
+              '🐙',
+              style: TextStyle(
+                fontSize: 12,
+                color: Color(0xFF6A6A6A),
+              ),
             ),
-          ),
+            const SizedBox(width: 4),
+            InkWell(
+              onTap: () => _launch('https://github.com/hfunescom'),
+              child: const Text(
+                'github.com/hfunescom',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Color(0xFF6A6A6A),
+                  decoration: TextDecoration.underline,
+                ),
+              ),
+            ),
+          ],
         ),
         const SizedBox(height: 8),
-        InkWell(
-          onTap: () => _launch('https://linkedin.com/in/hernan-javier-funes'),
-          child: const Text(
-            '💼 http://linkedin.com/in/hernan-javier-funes',
-            style: TextStyle(
-              fontSize: 12,
-              color: Color(0xFF6A6A6A),
-              decoration: TextDecoration.underline,
+        Row(
+          children: [
+            const Text(
+              '💼',
+              style: TextStyle(
+                fontSize: 12,
+                color: Color(0xFF6A6A6A),
+              ),
             ),
-          ),
+            const SizedBox(width: 4),
+            InkWell(
+              onTap: () => _launch('https://linkedin.com/in/hernan-javier-funes'),
+              child: const Text(
+                'http://linkedin.com/in/hernan-javier-funes',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Color(0xFF6A6A6A),
+                  decoration: TextDecoration.underline,
+                ),
+              ),
+            ),
+          ],
         ),
         const SizedBox(height: 16),
       ],


### PR DESCRIPTION
## Summary
- keep emojis in header next to links without making them part of the link

## Testing
- ❌ `dart format lib/header/header_column.dart` *(fails: command not found)*
- ❌ `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685466f2b898832ca8c394158954773d