### PR TITLE
Remove emojis from social links

### DIFF
--- a/lib/header/header_column.dart
+++ b/lib/header/header_column.dart
@@ -25,21 +25,13 @@ class HeaderColumn extends StatelessWidget {
         const SizedBox(height: 8),
         Row(
           children: [
-            const Text(
-              '🐙',
-              style: TextStyle(
-                fontSize: 12,
-                color: Color(0xFF6A6A6A),
-              ),
-            ),
-            const SizedBox(width: 4),
             InkWell(
               onTap: () => _launch('https://github.com/hfunescom'),
               child: const Text(
                 'github.com/hfunescom',
                 style: TextStyle(
                   fontSize: 12,
-                  color: Color(0xFF6A6A6A),
+                  color: Colors.blue,
                   decoration: TextDecoration.underline,
                 ),
               ),
@@ -49,21 +41,13 @@ class HeaderColumn extends StatelessWidget {
         const SizedBox(height: 8),
         Row(
           children: [
-            const Text(
-              '💼',
-              style: TextStyle(
-                fontSize: 12,
-                color: Color(0xFF6A6A6A),
-              ),
-            ),
-            const SizedBox(width: 4),
             InkWell(
               onTap: () => _launch('https://linkedin.com/in/hernan-javier-funes'),
               child: const Text(
                 'linkedin.com/in/hernan-javier-funes',
                 style: TextStyle(
                   fontSize: 12,
-                  color: Color(0xFF6A6A6A),
+                  color: Colors.blue,
                   decoration: TextDecoration.underline,
                 ),
               ),


### PR DESCRIPTION
## Summary
- drop emojis from GitHub and LinkedIn links in `HeaderColumn`
- use standard blue color for hyperlinks

## Testing
- `dart format -o none --set-exit-if-changed lib/header/header_column.dart` *(fails: command not found)*
- `flutter format lib/header/header_column.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546fef486c832c9ac50e911209464d