### PR TITLE
Fix languages section font size

### DIFF
--- a/lib/body_column/languages_section.dart
+++ b/lib/body_column/languages_section.dart
@@ -17,11 +17,11 @@ class LanguagesSection extends StatelessWidget {
         SizedBox(height: 24.0),
         Text(
           '• Native Spanish.',
-          style: const TextStyle(fontSize: 10, color: Colors.black),
+          style: const TextStyle(fontSize: 12, color: Colors.black),
         ),
         Text(
           '• English B1+ (Learning)',
-          style: const TextStyle(fontSize: 10, color: Colors.black),
+          style: const TextStyle(fontSize: 12, color: Colors.black),
         ),
         // Agrega más idiomas aquí...
       ],


### PR DESCRIPTION
## Summary
- bump the text size for the languages list items to 12px

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854824c3774832cb237d7b8d1a6dc45